### PR TITLE
Meta-data for request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,33 @@ person2.resource.delete();
 
 Whether this makes sense will depend on your application architecture, but ain't it nice to have options?
 
+### Passing meta-data to callbacks
+Oftentimes when your request finishes and the promise resolves you need to know more about the context in which the request was made. The resource proxy meta-data exists for this purpose. You can add any meta-data to a resource proxy and it will be passed in the `res` or `err` object when the promise is resolved or rejected.
+
+```javascript
+function onComplete(res) {
+  console.log(res.meta.org_id); // 4
+}
+
+Z.resource('/orgs/4/people')
+  .meta('org_id', 4)
+  .get()
+  .then(onComplete);
+```
+
+The `meta()` method can be passed a key-value pair like above, or a full object, in which case the contents will be copied to the internal meta object.
+
+```javascript
+Z.resource('/orgs/4/people').meta({
+  // My custom meta-data
+  org_id: 4,
+  reason: 'search',
+  redir_on_success: '/done'
+}).get();
+```
+
+This allows you to send along complex meta-data to your callbacks.
+
 ## Advanced use
 In most cases, nothing more than getting hold of the `Z` object and authenticating via `authenticate()` is necessary. However to some users, there might be cases where one would want to configure the SDK or create multiple instances to talk to separate back-ends.
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ var Zetkin = function() {
     /**
      * Make request via HTTP or HTTPS depending on the configuration.
     */
-    var _request = function(options, data) {
+    var _request = function(options, data, meta) {
         var client = _config.ssl? https : http;
 
         options.withCredentials = false;
@@ -125,12 +125,14 @@ var Zetkin = function() {
                     if (success) {
                         resolve({
                             data: data,
+                            meta: meta,
                             httpStatus: res.statusCode
                         });
                     }
                     else {
                         reject({
                             data: data,
+                            meta: meta,
                             httpStatus: res.statusCode
                         });
                     }
@@ -153,8 +155,24 @@ var Zetkin = function() {
 
 
 var ZetkinResourceProxy = function(z, path, _request) {
+    var _meta = {};
+
     this.getPath = function() {
         return path;
+    };
+
+    this.meta = function(keyOrObj, valueIfAny) {
+        if (arguments.length == 2) {
+            _meta[keyOrObj] = valueIfAny;
+        }
+        else {
+            var key;
+            for (key in keyOrObj) {
+                _meta[key] = keyOrObj[key];
+            }
+        }
+
+        return this;
     };
 
     this.get = function() {
@@ -163,7 +181,7 @@ var ZetkinResourceProxy = function(z, path, _request) {
             path: path
         };
 
-        return _request(opts, null);
+        return _request(opts, null, _meta);
     };
 
     this.post = function(data) {
@@ -172,7 +190,7 @@ var ZetkinResourceProxy = function(z, path, _request) {
             path: path
         };
 
-        return _request(opts, data);
+        return _request(opts, data, _meta);
     };
 
     this.patch = function(data) {
@@ -181,7 +199,7 @@ var ZetkinResourceProxy = function(z, path, _request) {
             path: path
         };
 
-        return _request(opts, data);
+        return _request(opts, data, _meta);
     };
 
     this.del = function() {
@@ -190,7 +208,7 @@ var ZetkinResourceProxy = function(z, path, _request) {
             path: path
         };
 
-        return _request(opts, null);
+        return _request(opts, null, _meta);
     };
 
     this.put = function(data) {
@@ -199,7 +217,7 @@ var ZetkinResourceProxy = function(z, path, _request) {
             path: path
         };
 
-        return _request(opts, data);
+        return _request(opts, data, _meta);
     };
 };
 


### PR DESCRIPTION
This adds a meta() method to ZetkinResourceProxy objects. It is useful for when
the promise callbacks need to know some context about the request. The data
defined with the meta() method is passed to both the resolve and reject promise
callbacks in the `res.meta` / `err.meta` object.
