### PR TITLE
Proper testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 .DS_Store
 coverage
+.nyc_output
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
+.DS_Store
+coverage
 node_modules

--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ var Z = new Zetkin()
 Z.construct = function(instanceOptions) {
     zetkin = new Zetkin();
     zetkin.configure(Z.getConfig());
-    zetkin.configure(instanceOptions);
+    zetkin.configure(instanceOptions || {});
     return zetkin;
 }
 

--- a/index.js
+++ b/index.js
@@ -244,10 +244,20 @@ var ZetkinResourceProxy = function(z, path, _request) {
             }
         }
 
-        if (filters && filters.length) {
-            for (var i = 0; i < filters.length; i++) {
-                var filter = filters[i].join('');
-                query.push('filter=' + encodeURIComponent(filter));
+        if (filters) {
+            if (filters.length) {
+                for (var i = 0; i < filters.length; i++) {
+                    if (filters[i].length !== 3) {
+                        throw new Error(
+                            'get() filters should be array of triplets');
+                    }
+
+                    var filter = filters[i].join('');
+                    query.push('filter=' + encodeURIComponent(filter));
+                }
+            }
+            else {
+                throw new Error('get() filters should be array of triplets');
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ var Zetkin = function() {
     }
 
     this.configure = function(options) {
+        if (!options) {
+            throw new Error('Options may not be undefined');
+        }
+
         for (var key in options) {
             if (key in _config) {
                 _config[key] = options[key];

--- a/index.js
+++ b/index.js
@@ -207,14 +207,22 @@ var ZetkinResourceProxy = function(z, path, _request) {
     };
 
     this.meta = function(keyOrObj, valueIfAny) {
-        if (arguments.length == 2) {
-            _meta[keyOrObj] = valueIfAny;
+        if (keyOrObj == null) {
+            throw new Error(
+                'Invalid meta() signature: Pass key and value or object');
         }
-        else {
+        else if (arguments.length == 1 && typeof keyOrObj == 'object') {
             var key;
             for (key in keyOrObj) {
                 _meta[key] = keyOrObj[key];
             }
+        }
+        else if (arguments.length == 2) {
+            _meta[keyOrObj] = valueIfAny;
+        }
+        else {
+            throw new Error(
+                'Invalid meta() signature: Pass key and value or object');
         }
 
         return this;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript SDK for the Zetkin platform for organizing activism",
   "main": "index.js",
   "scripts": {
-    "test": "mocha $(find test -name '*.js')"
+    "test": "nyc --reporter=html --reporter=text mocha $(find test -name '*.js')"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/zetkin/zetkin-js",
   "devDependencies": {
     "mocha": "^4.0.1",
+    "nyc": "^11.3.0",
     "proxyquire": "^1.8.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Javascript SDK for the Zetkin platform for organizing activism",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/jasmine"
+    "test": "mocha $(find test -name '*.js')"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/zetkin/zetkin-js",
   "devDependencies": {
-    "jasmine": "^2.3.1"
+    "mocha": "^4.0.1",
+    "proxyquire": "^1.8.0"
   },
   "dependencies": {
     "hawk": "^6.0.0",

--- a/test/configure.js
+++ b/test/configure.js
@@ -8,10 +8,10 @@ const mockHttpClient = require('./helpers').mockHttpClient;
 
 describe('configure()', () => {
     it('accepts known properties', () => {
-        let Z = require('../');
+        let z = require('../').construct();
 
         assert.doesNotThrow(() => {
-            Z.configure({
+            z.configure({
                 host: 'api.dev.zetkin.org',
                 version: 1,
                 ssl: false,
@@ -19,26 +19,42 @@ describe('configure()', () => {
         });
     });
 
+    it('stores and returns config through getConfig()', () => {
+        let z = require('../').construct();
+
+        z.configure({
+            host: 'api.dev.zetkin.org',
+            version: 1857,
+            ssl: false,
+        });
+
+        let config = z.getConfig();
+
+        assert.equal(config.host, 'api.dev.zetkin.org');
+        assert.equal(config.version, 1857);
+        assert.equal(config.ssl, false);
+    });
+
     it('throws error when invoked without properties', () => {
-        let Z = require('../');
+        let z = require('../').construct();
 
         assert.throws(() => {
-            Z.configure();
+            z.configure();
         }, /Options may not be undefined/);
     });
 
     it('throws error for unknown property', () => {
-        let Z = require('../');
+        let z = require('../');
 
         assert.throws(() => {
-            Z.configure({
+            z.configure({
                 foo: 'value',
             });
         }, /Unknown config option: foo/);
     });
 
     it('respects domain setting when making requests', done => {
-        let Z = proxyquire('../', {
+        let z = proxyquire('../', {
             https: mockHttpClient({
                 validateRequestCount: 1,
                 done: done,
@@ -46,47 +62,47 @@ describe('configure()', () => {
                     assert.equal(opts.hostname, 'api.dummy.zetkin.org');
                 },
             }),
-        });
+        }).construct();
 
-        Z.configure({
+        z.configure({
             host: 'api.dummy.zetkin.org',
         });
 
-        Z.resource('org', 1, 'campaigns')
+        z.resource('org', 1, 'campaigns')
             .get()
             .catch(err => done(err));
     });
 
     it('defaults to TLS=true when making requests', done => {
-        let Z = proxyquire('../', {
+        let z = proxyquire('../', {
             http: mockHttpClient({
                 done: () => done('Expected HTTPS but used HTTP'),
             }),
             https: mockHttpClient({
                 done: done,
             }),
-        });
+        }).construct();
 
-        Z.resource('org', 1, 'campaigns')
+        z.resource('org', 1, 'campaigns')
             .get()
             .catch(err => done(err));
     });
 
     it('respects TLS=false when making requests', done => {
-        let Z = proxyquire('../', {
+        let z = proxyquire('../', {
             http: mockHttpClient({
                 done: done,
             }),
             https: mockHttpClient({
                 done: () => done('Expected HTTP but used HTTPS'),
             }),
-        });
+        }).construct();
 
-        Z.configure({
+        z.configure({
             ssl: false,
         });
 
-        Z.resource('org', 1, 'campaigns')
+        z.resource('org', 1, 'campaigns')
             .get()
             .catch(err => done(err));
     });

--- a/test/configure.js
+++ b/test/configure.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+const mockHttpClient = require('./helpers').mockHttpClient;
+
+
+describe('configure()', () => {
+    it('accepts known properties', () => {
+        let Z = require('../');
+
+        assert.doesNotThrow(() => {
+            Z.configure({
+                host: 'api.dev.zetkin.org',
+                version: 1,
+                ssl: false,
+            });
+        });
+    });
+
+    it('throws error when invoked without properties', () => {
+        let Z = require('../');
+
+        assert.throws(() => {
+            Z.configure();
+        }, /Options may not be undefined/);
+    });
+
+    it('throws error for unknown property', () => {
+        let Z = require('../');
+
+        assert.throws(() => {
+            Z.configure({
+                foo: 'value',
+            });
+        }, /Unknown config option: foo/);
+    });
+
+    it('respects domain setting when making requests', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                validateRequestCount: 1,
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.hostname, 'api.dummy.zetkin.org');
+                },
+            }),
+        });
+
+        Z.configure({
+            host: 'api.dummy.zetkin.org',
+        });
+
+        Z.resource('org', 1, 'campaigns')
+            .get()
+            .catch(err => done(err));
+    });
+
+    it('defaults to TLS=true when making requests', done => {
+        let Z = proxyquire('../', {
+            http: mockHttpClient({
+                done: () => done('Expected HTTPS but used HTTP'),
+            }),
+            https: mockHttpClient({
+                done: done,
+            }),
+        });
+
+        Z.resource('org', 1, 'campaigns')
+            .get()
+            .catch(err => done(err));
+    });
+
+    it('respects TLS=false when making requests', done => {
+        let Z = proxyquire('../', {
+            http: mockHttpClient({
+                done: done,
+            }),
+            https: mockHttpClient({
+                done: () => done('Expected HTTP but used HTTPS'),
+            }),
+        });
+
+        Z.configure({
+            ssl: false,
+        });
+
+        Z.resource('org', 1, 'campaigns')
+            .get()
+            .catch(err => done(err));
+    });
+});

--- a/test/construct.js
+++ b/test/construct.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert');
+
+describe('construct()', () => {
+    it('creates a new Z instance', () => {
+        let Z = require('../');
+        let instance = Z.construct();
+
+        assert.ok(instance.resource);
+        assert.ok(instance.configure);
+        assert.ok(instance.getConfig);
+    });
+
+    it('copies options from original', () => {
+        let Z = require('../');
+        let instance = Z.construct();
+
+        assert.deepEqual(Z.getConfig(), instance.getConfig());
+    });
+
+    it('overwrites config with instance options', () => {
+        let version = Math.random();
+        let Z = require('../');
+        let instance = Z.construct({ version });
+
+        assert.equal(instance.getConfig().host, Z.getConfig().host);
+        assert.equal(instance.getConfig().version, version);
+        assert.notEqual(Z.getConfig().version, version);
+    });
+});

--- a/test/getFilters.js
+++ b/test/getFilters.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+const Z = require('../');
+const mockHttpClient = require('./helpers').mockHttpClient;
+
+
+describe('get() filters', () => {
+    it('accepts null', () => {
+        assert.doesNotThrow(() => {
+            Z.resource('session')
+                .get(null, null, null);
+        });
+    });
+
+    it('accepts an array of triplets', () => {
+        assert.doesNotThrow(() => {
+            Z.resource('session')
+                .get(null, null, [
+                    ['param1', '==', 1],
+                    ['param2', '==', 2],
+                ])
+        });
+    });
+
+    it('throws error for array of non-triplets', () => {
+        assert.throws(() => {
+            Z.resource('session')
+                .get(null, null, [
+                    ['param1', '=='],
+                ]);
+        }, /get\(\) filters should be array of triplets/);
+    });
+
+    it('throws error for non-array', () => {
+        assert.throws(() => {
+            Z.resource('session')
+                .get(null, null, {});
+        }, /get\(\) filters should be array of triplets/);
+    });
+
+    it('generates correct query string for single filter', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.path,
+                        '/v1/session?filter=param1%3D%3D1');
+                },
+            }),
+        });
+
+        Z.resource('session')
+            .get(null, null, [
+                [ 'param1', '==', 1 ],
+            ]);
+    });
+
+    it('generates correct query string for two filters', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.path,
+                        '/v1/session?filter=param1%3D%3D1&filter=param2%3D%3D2');
+                },
+            }),
+        });
+
+        Z.resource('session')
+            .get(null, null, [
+                [ 'param1', '==', 1 ],
+                [ 'param2', '==', 2 ],
+            ]);
+    });
+});

--- a/test/getPagination.js
+++ b/test/getPagination.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+const mockHttpClient = require('./helpers').mockHttpClient;
+
+
+describe('get() pagination', () => {
+    it('handles page argument', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.path, '/v1/session?p=2');
+                },
+            }),
+        });
+
+        Z.resource('session')
+            .get(2);
+    });
+
+    it('handles page and perPage arguments', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.path, '/v1/session?p=2&pp=100');
+                },
+            }),
+        });
+
+        Z.resource('session')
+            .get(2, 100);
+    });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,74 @@
+'use strict';
+
+
+const MOCK_CLIENT_DEFAULTS = {
+    done: () => {},
+    validateRequestOptions: opts => true,
+    validateRequestData: data => true,
+    mockResponseStatus: 200,
+    mockResponseData: {},
+};
+
+const mockHttpClient = mockOpts => {
+    mockOpts = Object.assign({}, MOCK_CLIENT_DEFAULTS, mockOpts);
+
+    let failed = false;
+    let reqOnError;
+    let resOnData;
+    let resOnEnd;
+
+    return {
+        request: (options, cb) => {
+            try {
+                mockOpts.validateRequestOptions(options);
+            }
+            catch (err) {
+                failed = true;
+                mockOpts.done(err);
+            }
+
+            return {
+                on: (ev, handler) => {
+                    if (ev == 'error') reqOnError = handler;
+                },
+                write: data => {
+                    try {
+                        !failed && mockOpts.validateRequestData(JSON.parse(data));
+                    }
+                    catch (err) {
+                        failed = true;
+                        mockOpts.done(err);
+                    }
+                },
+                end: () => {
+                    process.nextTick(() => {
+                        if (mockOpts.mockError) {
+                            reqOnError(mockOpts.mockError);
+                        }
+                        else {
+                            let data = JSON.stringify(mockOpts.mockResponseData);
+
+                            resOnData(data);
+                            resOnEnd();
+                        }
+
+                        !failed && mockOpts.done();
+                    });
+
+                    cb({
+                        statusCode: mockOpts.mockResponseStatus,
+                        on: (ev, handler) => {
+                            if (ev == 'data') resOnData = handler;
+                            else if (ev == 'end') resOnEnd = handler;
+                        },
+                    })
+                },
+            }
+        },
+    };
+};
+
+
+module.exports = {
+    mockHttpClient,
+};

--- a/test/meta.js
+++ b/test/meta.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+const Z = require('../');
+const mockHttpClient = require('./helpers').mockHttpClient;
+
+
+describe('resource proxy meta()', () => {
+    it('accepts key and value', () => {
+        assert.doesNotThrow(() => {
+            Z.resource('session')
+                .meta('key', 'value');
+        });
+    });
+
+    it('accepts object', () => {
+        assert.doesNotThrow(() => {
+            Z.resource('session')
+                .meta({
+                    first_name: 'Clara',
+                    last_name: 'Zetkin',
+                });
+        });
+    });
+
+    it('throws error for non-object single argument', () => {
+        assert.throws(() => {
+            Z.resource('session')
+                .meta(1);
+        }, /Invalid meta\(\) signature.*/);
+
+        assert.throws(() => {
+            Z.resource('session')
+                .meta('key');
+        }, /Invalid meta\(\) signature.*/);
+
+        assert.throws(() => {
+            Z.resource('session')
+                .meta(null);
+        }, /Invalid meta\(\) signature.*/);
+    });
+
+    it('throws error for more than two arguments', () => {
+        assert.throws(() => {
+            Z.resource('session')
+                .meta(1, 2, 3);
+        }, /Invalid meta\(\) signature.*/);
+    });
+
+    it('throws error for zero arguments', () => {
+        assert.throws(() => {
+            Z.resource('session')
+                .meta();
+        }, /Invalid meta\(\) signature.*/);
+    });
+
+    it('passes metadata to response', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient(),
+        });
+
+        Z.resource('session')
+            .meta('one', 1)
+            .meta({
+                two: 2,
+                three: 3,
+            })
+            .get()
+            .then(res => {
+                assert.deepEqual(res.meta, {
+                    one: 1,
+                    two: 2,
+                    three: 3,
+                });
+
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it('passes metadata to error', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                mockResponseStatus: 404,
+            }),
+        });
+
+        Z.resource('session')
+            .meta('one', 1)
+            .meta({
+                two: 2,
+                three: 3,
+            })
+            .get()
+            .catch(err => {
+                assert.deepEqual(err.meta, {
+                    one: 1,
+                    two: 2,
+                    three: 3,
+                });
+
+                done();
+            })
+            .catch(err => done(err));
+    });
+});

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert');
+
+const Z = require('../');
+
+
+describe('resource()', () => {
+    it('creates a resource proxy with the right methods', () => {
+        let r = Z.resource('/users/me');
+
+        assert.equal(typeof(r.get), 'function');
+        assert.equal(typeof(r.post), 'function');
+        assert.equal(typeof(r.patch), 'function');
+        assert.equal(typeof(r.del), 'function');
+    });
+
+    it('creates a resource proxy with the right path', () => {
+        let r = Z.resource('/users/me');
+        assert.equal(r.getPath(), '/v1/users/me');
+    });
+
+    it('generates the correct path from components', () => {
+        let r = Z.resource('users', 'me');
+        assert.equal(r.getPath(), '/v1/users/me');
+    });
+});

--- a/test/resourceProxy.js
+++ b/test/resourceProxy.js
@@ -3,74 +3,7 @@
 const assert = require('assert');
 const proxyquire = require('proxyquire');
 
-const Z = require('../');
-
-const MOCK_CLIENT_DEFAULTS = {
-    done: () => {},
-    validateRequestOptions: opts => true,
-    validateRequestData: data => true,
-    mockResponseStatus: 200,
-    mockResponseData: {},
-};
-
-const mockHttpClient = mockOpts => {
-    mockOpts = Object.assign({}, MOCK_CLIENT_DEFAULTS, mockOpts);
-
-    let failed = false;
-    let reqOnError;
-    let resOnData;
-    let resOnEnd;
-
-    return {
-        request: (options, cb) => {
-            try {
-                mockOpts.validateRequestOptions(options);
-            }
-            catch (err) {
-                failed = true;
-                mockOpts.done(err);
-            }
-
-            return {
-                on: (ev, handler) => {
-                    if (ev == 'error') reqOnError = handler;
-                },
-                write: data => {
-                    try {
-                        !failed && mockOpts.validateRequestData(JSON.parse(data));
-                    }
-                    catch (err) {
-                        failed = true;
-                        mockOpts.done(err);
-                    }
-                },
-                end: () => {
-                    process.nextTick(() => {
-                        if (mockOpts.mockError) {
-                            reqOnError(mockOpts.mockError);
-                        }
-                        else {
-                            let data = JSON.stringify(mockOpts.mockResponseData);
-
-                            resOnData(data);
-                            resOnEnd();
-                        }
-
-                        !failed && mockOpts.done();
-                    });
-
-                    cb({
-                        statusCode: mockOpts.mockResponseStatus,
-                        on: (ev, handler) => {
-                            if (ev == 'data') resOnData = handler;
-                            else if (ev == 'end') resOnEnd = handler;
-                        },
-                    })
-                },
-            }
-        },
-    };
-};
+const mockHttpClient = require('./helpers').mockHttpClient;
 
 
 describe('resource proxy', () => {
@@ -87,7 +20,6 @@ describe('resource proxy', () => {
 
         Z.resource('users', 'me')
             .get()
-            .catch(err => console.log(err))
             .catch(err => done(err));
     });
 

--- a/test/resourceProxy.js
+++ b/test/resourceProxy.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+const Z = require('../');
+
+const mockHttpClient = mockOpts => {
+    mockOpts = mockOpts || {};
+
+    let failed = false;
+    let reqOnError;
+    let resOnData;
+    let resOnEnd;
+
+    return {
+        request: (options, cb) => {
+            if (mockOpts.validateRequestOptions) {
+                try {
+                    mockOpts.validateRequestOptions(options);
+                }
+                catch (err) {
+                    failed = true;
+                    mockOpts.done(err);
+                }
+            }
+
+            return {
+                on: (ev, handler) => {
+                    if (ev == 'error') reqOnError = handler;
+                },
+                write: data => {
+                    if (!failed && mockOpts.validateRequestData) {
+                        try {
+                            mockOpts.validateRequestData(JSON.parse(data));
+                        }
+                        catch (err) {
+                            failed = true;
+                            mockOpts.done(err);
+                        }
+                    }
+                },
+                end: () => {
+                    process.nextTick(() => {
+                        let data = mockOpts.mockResponseData?
+                            JSON.stringify(mockOpts.mockResponseData) : '';
+
+                        resOnData(data);
+                        resOnEnd();
+
+                        if (!failed) {
+                            mockOpts.done();
+                        }
+                    });
+
+                    cb({
+                        statusCode: mockOpts.mockResponseStatus || 200,
+                        on: (ev, handler) => {
+                            if (ev == 'data') resOnData = handler;
+                            else if (ev == 'end') resOnEnd = handler;
+                        },
+                    })
+                },
+            }
+        },
+    };
+};
+
+
+describe('resource proxy', () => {
+    it('get() makes correct request', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.method, 'GET');
+                    assert.equal(opts.path, '/v1/users/me');
+                },
+            }),
+        });
+
+        Z.resource('users', 'me')
+            .get()
+            .catch(err => console.log(err))
+            .catch(err => done(err));
+    });
+
+    it('patch() makes correct request', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.method, 'PATCH');
+                    assert.equal(opts.path, '/v1/users/me');
+                },
+                validateRequestData: data => {
+                    assert.deepEqual(data, { first_name: 'Clara' });
+                },
+            }),
+        });
+
+        Z.resource('users', 'me')
+            .patch({ first_name: 'Clara' })
+            .catch(err => done(err));
+    });
+
+    it('post() makes correct request', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.method, 'POST');
+                    assert.equal(opts.path, '/v1/users/me');
+                },
+                validateRequestData: data => {
+                    assert.deepEqual(data, { first_name: 'Clara' });
+                },
+            }),
+        });
+
+        Z.resource('users', 'me')
+            .post({ first_name: 'Clara' })
+            .catch(err => done(err));
+    });
+
+    it('del() makes correct request', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.method, 'DELETE');
+                    assert.equal(opts.path, '/v1/users/me');
+                },
+            }),
+        });
+
+        Z.resource('users', 'me')
+            .del()
+            .catch(err => done(err));
+    });
+
+});

--- a/test/resourceProxy.js
+++ b/test/resourceProxy.js
@@ -77,6 +77,22 @@ describe('resource proxy', () => {
             .catch(err => done(err));
     });
 
+    it('put() makes correct request', done => {
+        let Z = proxyquire('../', {
+            https: mockHttpClient({
+                done: done,
+                validateRequestOptions: opts => {
+                    assert.equal(opts.method, 'PUT');
+                    assert.equal(opts.path, '/v1/users/me');
+                },
+            }),
+        });
+
+        Z.resource('users', 'me')
+            .put()
+            .catch(err => done(err));
+    });
+
     it('correctly throws error for non-2xx status-code', done => {
         let Z = proxyquire('../', {
             https: mockHttpClient({


### PR DESCRIPTION
Implement basic testing for entire SDK, using [mocha](https://mochajs.org) and native `assert`. This is a first step towards the major refactor that is OAuth 2.0 support (see #22).

* Fixes #9
* Fixes #16