### PR TITLE
Add support for scopes to login URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,11 +115,12 @@ var Zetkin = function() {
         return null;
     }
 
-    this.getLoginUrl = function(redirectUri) {
+    this.getLoginUrl = function(redirectUri, scopes) {
         _validateClientConfiguration();
 
         var opts = {
             redirectUri: redirectUri,
+            scopes: scopes,
         };
 
         return _config.clientSecret?


### PR DESCRIPTION
This PR exposes the [_scope_ feature of OAuth2](https://oauth.net/2/scope/) (and the client library we use) so that SDK users can optionally supply a `scopes` array when constructing a login URL.

Scopes will be gradually added to the Zetkin Platform API, starting with using scopes to indicate the requested auth level (single or multi-factor authentication).