### PR TITLE
Fix incorrect error message that triggers token refresh attempt

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ var Zetkin = function() {
             .catch(err => {
                 if (err && err.httpStatus == 401) {
                     let originalError = err;
-                    if (err.data && err.data.error == 'Key has expired, please renew') {
+                    if (err.data && err.data.error == 'invalid_token') {
                         return _token
                             .refresh()
                             .then(token => {


### PR DESCRIPTION
The new Zetkin API gateway has a different way of reporting expired tokens, so the SDK must be updated to properly trigger token refresh when it expies.